### PR TITLE
Updated to support the gem to work with jquery-ui-rails (5.0.0)

### DIFF
--- a/vendor/assets/javascripts/jqgrid-jquery-rails.js
+++ b/vendor/assets/javascripts/jqgrid-jquery-rails.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require jquery.ui.all
+//= require jquery-ui
 
 //= require i18n/grid.locale-en
 //= require jquery.jqGrid.js

--- a/vendor/assets/stylesheets/jqgrid-jquery-rails.css
+++ b/vendor/assets/stylesheets/jqgrid-jquery-rails.css
@@ -1,6 +1,6 @@
 /*
 provides jquery ui theme 'smoothness' from gem 'jquery-ui-rails':
-= require jquery.ui.all
+= require jquery-ui
 
 = require ui.jqgrid
 */


### PR DESCRIPTION
The gem was throwing an error, jquery.ui.all not found. Causing issue
for the those who updated to jquery-ui-rails (5.0.0)
