### PR TITLE
Fix #76 Update jquery-ui-rails to v5.0.2

### DIFF
--- a/jqgrid-jquery-rails.gemspec
+++ b/jqgrid-jquery-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 3.1'
   spec.add_dependency 'jquery-rails'
-  spec.add_dependency 'jquery-ui-rails', '< 5.0.0'
+  spec.add_dependency 'jquery-ui-rails', '>= 5.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'capybara', '~> 2.4.3'

--- a/vendor/assets/javascripts/jqgrid-jquery-rails.js
+++ b/vendor/assets/javascripts/jqgrid-jquery-rails.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require jquery.ui.all
+//= require jquery-ui
 
 //= require i18n/grid.locale-en
 //= require jquery.jqGrid.js

--- a/vendor/assets/stylesheets/jqgrid-jquery-rails.css
+++ b/vendor/assets/stylesheets/jqgrid-jquery-rails.css
@@ -1,6 +1,6 @@
 /*
 provides jquery ui theme 'smoothness' from gem 'jquery-ui-rails':
-= require jquery.ui.all
+= require jquery-ui
 
 = require ui.jqgrid
 */


### PR DESCRIPTION
- this is potentially a breaking change since we're forcing the use of
  jquery-ui-rails > 5.0.0
